### PR TITLE
Updates

### DIFF
--- a/.buckconfig
+++ b/.buckconfig
@@ -1,6 +1,6 @@
 
 [android]
-  target = Google Inc.:Google APIs:23
+  target = Google Inc.:Google APIs:26
 
 [maven_repositories]
   central = https://repo1.maven.org/maven2

--- a/android/.project
+++ b/android/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>F82017</name>
+	<name>ODD2019</name>
 	<comment>Project android created by Buildship.</comment>
 	<projects>
 	</projects>

--- a/android/.project
+++ b/android/.project
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>F82017</name>
+	<comment>Project android created by Buildship.</comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.buildship.core.gradleprojectbuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.buildship.core.gradleprojectnature</nature>
+	</natures>
+</projectDescription>

--- a/android/.settings/org.eclipse.buildship.core.prefs
+++ b/android/.settings/org.eclipse.buildship.core.prefs
@@ -1,0 +1,2 @@
+connection.project.dir=
+eclipse.preferences.version=1

--- a/android/app/.classpath
+++ b/android/app/.classpath
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8/"/>
+	<classpathentry kind="con" path="org.eclipse.buildship.core.gradleclasspathcontainer"/>
+	<classpathentry kind="output" path="bin"/>
+</classpath>

--- a/android/app/.project
+++ b/android/app/.project
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>app</name>
+	<comment>Project app created by Buildship.</comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.buildship.core.gradleprojectbuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+		<nature>org.eclipse.buildship.core.gradleprojectnature</nature>
+	</natures>
+</projectDescription>

--- a/android/app/.settings/org.eclipse.buildship.core.prefs
+++ b/android/app/.settings/org.eclipse.buildship.core.prefs
@@ -1,0 +1,2 @@
+connection.project.dir=..
+eclipse.preferences.version=1

--- a/android/app/BUCK
+++ b/android/app/BUCK
@@ -46,13 +46,13 @@ android_library(
 
 android_build_config(
   name = 'build_config',
-  package = 'com.f82017',
+  package = 'ca.edmonton.oddconf',
 )
 
 android_resource(
   name = 'res',
   res = 'src/main/res',
-  package = 'com.f82017',
+  package = 'ca.edmonton.oddconf',
 )
 
 android_binary(

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -138,7 +138,7 @@ dependencies {
     }
     compile "com.facebook.android:facebook-android-sdk:4.22.1"
     compile fileTree(dir: "libs", include: ["*.jar"])
-    compile "com.android.support:appcompat-v7:28.0.0"
+    compile "com.android.support:appcompat-v7:26.+"
     compile "com.facebook.react:react-native:+"  // From node_modules
 }
 

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -87,9 +87,9 @@ android {
     buildToolsVersion "28.0.3"
 
     defaultConfig {
-        applicationId "com.facebook.f8"
+        applicationId "ca.edmonton.oddconf"
         minSdkVersion 16
-        targetSdkVersion 23
+        targetSdkVersion 26
         versionCode 10000410
         versionName "4.0.0"
         ndk {
@@ -138,7 +138,7 @@ dependencies {
     }
     compile "com.facebook.android:facebook-android-sdk:4.22.1"
     compile fileTree(dir: "libs", include: ["*.jar"])
-    compile "com.android.support:appcompat-v7:23.0.1"
+    compile "com.android.support:appcompat-v7:28.0.0"
     compile "com.facebook.react:react-native:+"  // From node_modules
 }
 

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,6 +1,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
-    package="com.facebook.f8"
+    package="ca.edmonton.oddconf"
     android:versionCode="1"
     android:versionName="1.0">
 
@@ -16,7 +16,7 @@
 
     <uses-sdk
         android:minSdkVersion="16"
-        android:targetSdkVersion="23" />
+        android:targetSdkVersion="26" />
 
     <application
       android:name=".MainApplication"

--- a/android/app/src/main/java/com/facebook/f8/MainActivity.java
+++ b/android/app/src/main/java/com/facebook/f8/MainActivity.java
@@ -13,7 +13,7 @@ public class MainActivity extends ReactActivity {
      */
     @Override
     protected String getMainComponentName() {
-        return "F82017";
+        return "ODD2019";
     }
 
     @Override

--- a/android/app/src/main/java/com/facebook/f8/MainActivity.java
+++ b/android/app/src/main/java/com/facebook/f8/MainActivity.java
@@ -1,4 +1,4 @@
-package com.facebook.f8;
+package ca.edmonton.oddconf;
 
 import com.facebook.react.ReactActivity;
 import android.content.Intent;

--- a/android/app/src/main/java/com/facebook/f8/MainApplication.java
+++ b/android/app/src/main/java/com/facebook/f8/MainApplication.java
@@ -1,4 +1,4 @@
-package com.facebook.f8;
+package ca.edmonton.oddconf;
 
 import android.app.Application;
 

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -1,4 +1,4 @@
-rootProject.name = 'F82017'
+rootProject.name = 'ODD2019'
 include ':react-native-linear-gradient'
 project(':react-native-linear-gradient').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-linear-gradient/android')
 include ':react-native-native-video-player'

--- a/app.json
+++ b/app.json
@@ -1,4 +1,4 @@
 {
-  "name": "F82017",
-  "displayName": "F82017"
+  "name": "ODD2019",
+  "displayName": "ODD2019"
 }

--- a/index.android.js
+++ b/index.android.js
@@ -1,4 +1,4 @@
 import { AppRegistry } from "react-native";
 import setup from "./js/setup";
 
-AppRegistry.registerComponent("F82017", setup);
+AppRegistry.registerComponent("ODD2019", setup);

--- a/index.ios.js
+++ b/index.ios.js
@@ -1,4 +1,4 @@
 import { AppRegistry } from "react-native";
 import setup from "./js/setup";
 
-AppRegistry.registerComponent("F82017", setup);
+AppRegistry.registerComponent("ODD2019", setup);

--- a/ios/F82017.xcodeproj/project.pbxproj
+++ b/ios/F82017.xcodeproj/project.pbxproj
@@ -1245,7 +1245,7 @@
 					"-ObjC",
 					"-lc++",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.parse.f8;
+				PRODUCT_BUNDLE_IDENTIFIER = ca.edmonton.oddconf;
 				PRODUCT_NAME = F82017;
 				VERSIONING_SYSTEM = "apple-generic";
 			};
@@ -1271,7 +1271,7 @@
 					"-ObjC",
 					"-lc++",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.parse.f8;
+				PRODUCT_BUNDLE_IDENTIFIER = ca.edmonton.oddconf;
 				PRODUCT_NAME = F82017;
 				VERSIONING_SYSTEM = "apple-generic";
 			};

--- a/ios/F82017.xcodeproj/project.pbxproj
+++ b/ios/F82017.xcodeproj/project.pbxproj
@@ -1246,7 +1246,7 @@
 					"-lc++",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = ca.edmonton.oddconf;
-				PRODUCT_NAME = F82017;
+				PRODUCT_NAME = ODD2019;
 				VERSIONING_SYSTEM = "apple-generic";
 			};
 			name = Debug;
@@ -1272,7 +1272,7 @@
 					"-lc++",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = ca.edmonton.oddconf;
-				PRODUCT_NAME = F82017;
+				PRODUCT_NAME = ODD2019;
 				VERSIONING_SYSTEM = "apple-generic";
 			};
 			name = Release;

--- a/ios/F82017/AppDelegate.m
+++ b/ios/F82017/AppDelegate.m
@@ -31,7 +31,7 @@
 #endif
 
   RCTRootView *rootView = [[RCTRootView alloc] initWithBundleURL:jsCodeLocation
-                                                      moduleName:@"F82017"
+                                                      moduleName:@"ODD2019"
                                                initialProperties:nil
                                                    launchOptions:launchOptions];
   rootView.backgroundColor = [[UIColor alloc] initWithRed:0.98f green:0.98f blue:0.94f alpha:1];

--- a/js/actions/installation.js
+++ b/js/actions/installation.js
@@ -34,7 +34,8 @@ async function currentInstallation(): Promise<Parse.Installation> {
     appName: "F8",
     deviceType: Platform.OS,
     // TODO: Get this information from the app itself
-    appIdentifier: Platform.OS === "ios" ? "com.parse.f8" : "com.facebook.f8"
+    // appIdentifier: Platform.OS === "ios" ? "com.parse.f8" : "com.facebook.f8"
+    appIdentifier: Platform.OS === "ca.edmonton.oddconf"
   });
 }
 

--- a/js/env.js
+++ b/js/env.js
@@ -25,7 +25,7 @@
 module.exports = {
   version: 410,
   testMenuEnabled: true,
-  parseAppID: "oss-f8-app-2017",
+  parseAppID: "odd-app-2019",
   serverURL: "http://35.247.62.130:1337",
   // serverURL: "http://162.106.109.3:1337", // Desktop
   // serverURL: "http://localhost:1337",

--- a/js/env.js
+++ b/js/env.js
@@ -25,8 +25,8 @@
 module.exports = {
   version: 410,
   testMenuEnabled: true,
-  // parseAppID: "oss-f8-app-2017", // F8 ID
-  parseAppID: "odd-app-2019", // New ID
+  parseAppID: "oss-f8-app-2017", // F8 ID
+  // parseAppID: "odd-app-2019", // New ID
   serverURL: "http://35.247.62.130:1337",
   // serverURL: "http://162.106.109.3:1337", // Desktop
   // serverURL: "http://localhost:1337",

--- a/js/env.js
+++ b/js/env.js
@@ -25,7 +25,8 @@
 module.exports = {
   version: 410,
   testMenuEnabled: true,
-  parseAppID: "odd-app-2019",
+  // parseAppID: "oss-f8-app-2017", // F8 ID
+  parseAppID: "odd-app-2019", // New ID
   serverURL: "http://35.247.62.130:1337",
   // serverURL: "http://162.106.109.3:1337", // Desktop
   // serverURL: "http://localhost:1337",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "F82017",
+  "name": "ODD2019",
   "version": "0.0.1",
   "private": true,
   "scripts": {

--- a/server/graphql/src/index.js
+++ b/server/graphql/src/index.js
@@ -29,9 +29,9 @@ import Parse from "parse/node";
 
 import schema from "./schema";
 
-Parse.initialize("oss-f8-app-2017");
+Parse.initialize("odd-app-2019");
 Parse.serverURL = process.env.PARSE_URL;
-Parse.masterKey = "oss-f8-app-2017-mk";
+Parse.masterKey = "odd-app-2019-mk";
 Parse.Cloud.useMasterKey();
 
 const app = express();

--- a/server/parse-dashboard/config.json
+++ b/server/parse-dashboard/config.json
@@ -2,8 +2,8 @@
   "apps": [
     {
         "serverURL": "http://localhost:1337/parse",
-        "appId": "oss-f8-app-2017",
-        "masterKey": "oss-f8-app-2017-mk",
+        "appId": "odd-app-2019",
+        "masterKey": "odd-app-2019-mk",
         "appName": "F8"
     }
   ],

--- a/server/parse-server/config.json
+++ b/server/parse-server/config.json
@@ -1,6 +1,6 @@
 {
-  "appId": "oss-f8-app-2017",
-  "masterKey": "oss-f8-app-2017-mk",
+  "appId": "odd-app-2019",
+  "masterKey": "odd-app-2019-mk",
   "databaseURI": "mongodb://mongo/dev",
   "cloud": "cloud-lib/index.js"
 }


### PR DESCRIPTION
Changes:
- updated package name to match COE's
- changed app/component names from *F82017* to *ODD2019*
- modified the Parse app ID and key references (Note: this will have to be changed on version that's on the cloud as well)
- updated target SDK version from *23* to *26*

These changes do not seem to break the functionality of the app, however, there are issues for the development build for Android on newer devices (API >= 26). This might be due to screen overlay permissions when pulling up the react-native developer menu.